### PR TITLE
fix: add field size check for public inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -612,6 +612,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "array-bytes",
+ "num-bigint",
  "serde",
  "serde_json",
  "solana-program",
@@ -829,11 +830,10 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.4"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608e7659b5c3d7cba262d894801b9ec9d00de989e8a82bd4bef91d08da45cdc0"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -851,19 +851,18 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "autocfg",
  "num-traits",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ ark-serialize = "0.4.2"
 ark-ec = "0.4.2"
 ark-ff = "0.4.2"
 ark-bn254 = "0.4.0"
+num-bigint = "0.4.6"
 
 
 [dev-dependencies]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -20,4 +20,6 @@ pub enum Groth16Error {
     DecompressingG1Failed,
     #[error("DecompressingG2Failed")]
     DecompressingG2Failed,
+    #[error("PublicInputGreaterThenFieldSize")]
+    PublicInputGreaterThenFieldSize,
 }


### PR DESCRIPTION
Issue:
- there is no explicit check that public inputs are less than field size

Changes:
- add optional check to `prepare_inputs` which checks that inputs are less than field size
- add `verify_unchecked` to bypass the checks for performance