### PR TITLE
fix: correct typo in error name and update syscall documentation

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -20,6 +20,6 @@ pub enum Groth16Error {
     DecompressingG1Failed,
     #[error("DecompressingG2Failed")]
     DecompressingG2Failed,
-    #[error("PublicInputGreaterThenFieldSize")]
-    PublicInputGreaterThenFieldSize,
+    #[error("PublicInputGreaterThanFieldSize")]
+    PublicInputGreaterThanFieldSize,
 }

--- a/src/groth16.rs
+++ b/src/groth16.rs
@@ -91,7 +91,7 @@ impl<const NR_INPUTS: usize> Groth16Verifier<'_, NR_INPUTS> {
 
         for (i, input) in self.public_inputs.iter().enumerate() {
             if CHECK && !is_less_than_bn254_field_size_be(input) {
-                return Err(Groth16Error::PublicInputGreaterThenFieldSize);
+                return Err(Groth16Error::PublicInputGreaterThanFieldSize);
             }
             let mul_res = alt_bn128_multiplication(
                 &[&self.verifyingkey.vk_ic[i + 1][..], &input[..]].concat(),
@@ -481,7 +481,7 @@ mod tests {
         );
         assert_eq!(
             verifier.verify(),
-            Err(Groth16Error::PublicInputGreaterThenFieldSize)
+            Err(Groth16Error::PublicInputGreaterThanFieldSize)
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! Verification takes less than 200,000 compute units.
 //!
-//! The syscalls are contained in Solana releases 1.15.0 onwards and yet to be activated on a public network.
+//! The syscalls are contained in Solana releases 1.18.x onwards and are active on mainnet-beta.
 //!
 //! Inputs need to be in u8 arrays in big endian.
 //!


### PR DESCRIPTION
# Fix Documentation and Error Message Typo

## Changes
- Corrected typo in error enum: changed "PublicInputGreaterThenFieldSize" to "PublicInputGreaterThanFieldSize"
- Updated documentation in lib.rs to correctly state that altbn254 syscalls are active